### PR TITLE
feat(serialize): overload table to render json on cmd end

### DIFF
--- a/cmd/blockchaincmd/describe.go
+++ b/cmd/blockchaincmd/describe.go
@@ -41,6 +41,7 @@ import (
 )
 
 var printGenesisOnly bool
+var AsJson bool
 
 // avalanche blockchain describe
 func newDescribeCmd() *cobra.Command {
@@ -60,6 +61,7 @@ flag, the command instead prints out the raw genesis file.`,
 		false,
 		"Print the genesis to the console directly instead of the summary",
 	)
+	cmd.Flags().BoolVarP(&AsJson, "json", "j", false, "Print the output in JSON format")
 	return cmd
 }
 
@@ -233,7 +235,7 @@ func PrintSubnetInfo(blockchainName string, onlyLocalnetInfo bool) error {
 
 	if locallyDeployed {
 		ux.Logger.PrintToUser("")
-		if err := localnet.PrintEndpoints(app, ux.Logger.PrintToUser, sc.Name); err != nil {
+		if err := localnet.PrintEndpoints(app, ux.Logger.PrintToUser, sc.Name, AsJson); err != nil {
 			return err
 		}
 
@@ -423,7 +425,7 @@ func printPrecompiles(genesis core.Genesis) {
 }
 
 func addPrecompileAllowListToTable(
-	t table.Writer,
+	t ux.CustomTable,
 	label string,
 	adminAddresses []common.Address,
 	managerAddresses []common.Address,
@@ -450,6 +452,7 @@ func addPrecompileAllowListToTable(
 }
 
 func describe(_ *cobra.Command, args []string) error {
+	ux.Table.SetAsJson(&AsJson)
 	blockchainName := args[0]
 	if !app.GenesisExists(blockchainName) {
 		ux.Logger.PrintToUser("The provided blockchain name %q does not exist", blockchainName)
@@ -473,5 +476,6 @@ func describe(_ *cobra.Command, args []string) error {
 		ux.Logger.PrintToUser("Printing genesis")
 		return printGenesis(blockchainName)
 	}
+	ux.Table.PrintIfJson()
 	return nil
 }

--- a/cmd/blockchaincmd/upgradecmd/apply.go
+++ b/cmd/blockchaincmd/upgradecmd/apply.go
@@ -53,7 +53,8 @@ var (
 	avalanchegoChainConfigFlag       = "avalanchego-chain-config-dir"
 	avalanchegoChainConfigDir        string
 
-	print bool
+	print  bool
+	AsJson bool
 )
 
 // avalanche blockchain upgrade apply
@@ -84,11 +85,13 @@ Refer to https://docs.avax.network/nodes/maintain/chain-config-flags#subnet-chai
 	cmd.Flags().BoolVar(&print, "print", false, "if true, print the manual config without prompting (for public networks only)")
 	cmd.Flags().BoolVar(&force, "force", false, "If true, don't prompt for confirmation of timestamps in the past")
 	cmd.Flags().StringVar(&avalanchegoChainConfigDir, avalanchegoChainConfigFlag, os.ExpandEnv(avalanchegoChainConfigDirDefault), "avalanchego's chain config file directory")
+	cmd.Flags().BoolVarP(&AsJson, "json", "j", false, "Print the output in JSON format")
 
 	return cmd
 }
 
 func applyCmd(_ *cobra.Command, args []string) error {
+	ux.Table.SetAsJson(&AsJson)
 	blockchainName := args[0]
 
 	if !app.BlockchainConfigExists(blockchainName) {
@@ -114,7 +117,7 @@ func applyCmd(_ *cobra.Command, args []string) error {
 	case mainnetDeployment:
 		return applyPublicNetworkUpgrade(blockchainName, models.Mainnet.String(), &sc)
 	}
-
+	ux.Table.PrintIfJson()
 	return nil
 }
 
@@ -224,7 +227,7 @@ func applyLocalNetworkUpgrade(blockchainName, networkKey string, sc *models.Side
 		}
 		ux.Logger.PrintToUser("The next upgrade will go into effect %s", time.Unix(nextUpgrade, 0).Local().Format(constants.TimeParseLayout))
 		ux.Logger.PrintToUser("")
-		if err := localnet.PrintEndpoints(app, ux.Logger.PrintToUser, blockchainName); err != nil {
+		if err := localnet.PrintEndpoints(app, ux.Logger.PrintToUser, blockchainName, AsJson); err != nil {
 			return err
 		}
 

--- a/cmd/networkcmd/start.go
+++ b/cmd/networkcmd/start.go
@@ -41,6 +41,7 @@ type StartFlags struct {
 }
 
 var startFlags StartFlags
+var AsJson bool
 
 func newStartCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -72,11 +73,13 @@ already running.`,
 		constants.LatestPreReleaseVersionTag,
 		"use this relayer version",
 	)
+	cmd.Flags().BoolVarP(&AsJson, "json", "j", false, "Print the output in JSON format")
 
 	return cmd
 }
 
 func start(*cobra.Command, []string) error {
+	ux.Table.SetAsJson(&AsJson)
 	return Start(startFlags, true)
 }
 
@@ -298,11 +301,11 @@ func Start(flags StartFlags, printEndpoints bool) error {
 	ux.Logger.PrintToUser("")
 
 	if printEndpoints {
-		if err := localnet.PrintEndpoints(app, ux.Logger.PrintToUser, ""); err != nil {
+		if err := localnet.PrintEndpoints(app, ux.Logger.PrintToUser, "", AsJson); err != nil {
 			return err
 		}
 	}
-
+	ux.Table.PrintIfJson()
 	return nil
 }
 

--- a/cmd/networkcmd/status.go
+++ b/cmd/networkcmd/status.go
@@ -11,7 +11,7 @@ import (
 )
 
 func newStatusCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Prints the status of the local network",
 		Long: `The network status command prints whether or not a local Avalanche
@@ -20,9 +20,12 @@ network is running and some basic stats about the network.`,
 		RunE: networkStatus,
 		Args: cobrautils.ExactArgs(0),
 	}
+	cmd.Flags().BoolVarP(&AsJson, "json", "j", false, "Print the output in JSON format")
+	return cmd
 }
 
 func networkStatus(*cobra.Command, []string) error {
+	ux.Table.SetAsJson(&AsJson)
 	clusterInfo, err := localnet.GetClusterInfo()
 	if err != nil {
 		if server.IsServerError(err, server.ErrNotBootstrapped) {
@@ -38,7 +41,7 @@ func networkStatus(*cobra.Command, []string) error {
 		ux.Logger.PrintToUser("  Network Healthy: %t", clusterInfo.Healthy)
 		ux.Logger.PrintToUser("  Custom VMs Healthy: %t", clusterInfo.CustomChainsHealthy)
 		ux.Logger.PrintToUser("")
-		if err := localnet.PrintEndpoints(app, ux.Logger.PrintToUser, ""); err != nil {
+		if err := localnet.PrintEndpoints(app, ux.Logger.PrintToUser, "", AsJson); err != nil {
 			return err
 		}
 	} else {
@@ -47,6 +50,6 @@ func networkStatus(*cobra.Command, []string) error {
 
 	// TODO: verbose output?
 	// ux.Logger.PrintToUser(status.String())
-
+	ux.Table.PrintIfJson()
 	return nil
 }

--- a/cmd/validatorcmd/list.go
+++ b/cmd/validatorcmd/list.go
@@ -25,6 +25,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var AsJson bool
+
 func NewListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list [blockchainName]",
@@ -35,10 +37,12 @@ func NewListCmd() *cobra.Command {
 	}
 
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, true, getBalanceSupportedNetworkOptions)
+	cmd.Flags().BoolVarP(&AsJson, "json", "j", false, "Print the output in JSON format")
 	return cmd
 }
 
 func list(_ *cobra.Command, args []string) error {
+	ux.Table.SetAsJson(&AsJson)
 	blockchainName := args[0]
 	sc, err := app.LoadSidecar(blockchainName)
 	if err != nil {
@@ -119,5 +123,6 @@ func list(_ *cobra.Command, args []string) error {
 		t.AppendRow(table.Row{nodeID, validationID, validator.Weight, float64(balance) / float64(units.Avax)})
 	}
 	fmt.Println(t.Render())
+	ux.Table.PrintIfJson()
 	return nil
 }

--- a/pkg/localnet/output.go
+++ b/pkg/localnet/output.go
@@ -22,6 +22,7 @@ func PrintEndpoints(
 	app *application.Avalanche,
 	printFunc func(msg string, args ...interface{}),
 	subnetName string,
+	AsJson bool,
 ) error {
 	clusterInfo, err := GetClusterInfo()
 	if err != nil {
@@ -29,19 +30,19 @@ func PrintEndpoints(
 	}
 	for _, chainInfo := range clusterInfo.CustomChains {
 		if subnetName == "" || chainInfo.ChainName == subnetName {
-			if err := PrintSubnetEndpoints(app, printFunc, clusterInfo, chainInfo); err != nil {
+			if err := PrintSubnetEndpoints(app, printFunc, clusterInfo, chainInfo, AsJson); err != nil {
 				return err
 			}
 			printFunc("")
 		}
 	}
-	if err := PrintNetworkEndpoints("Primary Nodes", printFunc, clusterInfo); err != nil {
+	if err := PrintNetworkEndpoints("Primary Nodes", printFunc, clusterInfo, AsJson); err != nil {
 		return err
 	}
 	clusterInfo, err = GetClusterInfoWithEndpoint(binutils.LocalClusterGRPCServerEndpoint)
 	if err == nil {
 		printFunc("")
-		if err := PrintNetworkEndpoints("L1 Nodes", printFunc, clusterInfo); err != nil {
+		if err := PrintNetworkEndpoints("L1 Nodes", printFunc, clusterInfo, AsJson); err != nil {
 			return err
 		}
 	}
@@ -53,6 +54,7 @@ func PrintSubnetEndpoints(
 	printFunc func(msg string, args ...interface{}),
 	clusterInfo *rpcpb.ClusterInfo,
 	chainInfo *rpcpb.CustomChainInfo,
+	AsJson bool,
 ) error {
 	nodeInfos := maps.Values(clusterInfo.NodeInfos)
 	nodeUris := utils.Map(nodeInfos, func(nodeInfo *rpcpb.NodeInfo) string { return nodeInfo.GetUri() })
@@ -94,6 +96,7 @@ func PrintNetworkEndpoints(
 	title string,
 	printFunc func(msg string, args ...interface{}),
 	clusterInfo *rpcpb.ClusterInfo,
+	AsJson bool,
 ) error {
 	header := table.Row{"Name", "Node ID", "Localhost Endpoint"}
 	insideCodespace := utils.InsideCodespace()

--- a/pkg/ux/progressbar.go
+++ b/pkg/ux/progressbar.go
@@ -31,17 +31,20 @@ func TimedProgressBar(
 			BarEnd:        "]",
 		}))
 	for i := 0; i < steps; i++ {
-		if err := bar.Add(1); err != nil {
+		if err := ExtraStepExecuted(bar); err != nil {
 			return nil, err
 		}
 		time.Sleep(stepDuration)
 	}
-	if extraSteps == 0 {
+	if extraSteps == 0 && !*Logger.muted{
 		fmt.Println()
 	}
 	return bar, nil
 }
 
 func ExtraStepExecuted(bar *progressbar.ProgressBar) error {
+	if Logger != nil && *Logger.muted {
+		return nil
+	}
 	return bar.Add(1)
 }

--- a/pkg/ux/spinner.go
+++ b/pkg/ux/spinner.go
@@ -44,10 +44,13 @@ func (us *UserSpinner) Stop() {
 
 func (us *UserSpinner) SpinToUser(msg string, args ...interface{}) *ysmrr.Spinner {
 	formattedMsg := fmt.Sprintf(msg, args...)
-	if Logger != nil {
+	if Logger != nil{
 		Logger.log.Info(formattedMsg + " [Spinner Start]")
 	}
 	sp := us.spinner.AddSpinner(formattedMsg)
+	if Logger != nil && *Logger.muted {
+		return sp
+	}
 	us.mutex.Lock()
 	if !us.started {
 		us.spinner.Start()
@@ -68,7 +71,9 @@ func SpinFailWithError(s *ysmrr.Spinner, txt string, err error) {
 }
 
 func SpinComplete(s *ysmrr.Spinner) {
-	ansi.CursorShow()
+	if Logger != nil && !*Logger.muted {
+		ansi.CursorShow()
+	}
 	if s.IsComplete() {
 		return
 	}

--- a/pkg/ux/table.go
+++ b/pkg/ux/table.go
@@ -3,18 +3,207 @@
 package ux
 
 import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
 )
 
-func DefaultTable(title string, header table.Row) table.Writer {
-	t := table.NewWriter()
+var Table *CustomTable
+
+// Wrapper for ux.DefaultTable to support JSON rendering.
+type CustomTable struct {
+	table.Writer
+	Name        string
+	Headers     []string
+	Data        map[string]interface{} // Holds the data for JSON rendering
+	ArrayData   []map[string]interface{}
+	AllData     map[string]interface{}
+	headerAdded bool
+	isArray     bool // Flag to differentiate between flat and hierarchical tables
+	AsJson      *bool
+}
+
+// Initializes a new CustomTable.
+func NewCustomTable(name string, headers table.Row) CustomTable {
+	if Table == nil {
+		Table = &CustomTable{
+			Writer:    table.NewWriter(),
+			Name:      name,
+			Data:      make(map[string]interface{}),
+			ArrayData: []map[string]interface{}{},
+			isArray:   headers != nil,
+			AllData:   make(map[string]interface{}),
+		}
+	} else {
+		// Reset the table except for the json array AllData
+		Table.Name = name
+		Table.Data = make(map[string]interface{})
+		Table.ArrayData = []map[string]interface{}{}
+		Table.isArray = headers != nil
+		Table.headerAdded = false
+		Table.Writer = table.NewWriter()
+	}
+	if headers != nil {
+		Table.AppendHeader(headers)
+	}
+	return *Table
+}
+
+func (jt *CustomTable) SetAsJson(AsJson *bool) {
+	jt.AsJson = AsJson
+	Logger.SetMute(AsJson)
+}
+
+// Appends headers to the table and stores them for JSON conversion.
+func (jt *CustomTable) AppendHeader(headers table.Row) {
+	if jt.headerAdded {
+		return
+	}
+	jt.headerAdded = true
+	if *jt.AsJson {
+		jt.Headers = make([]string, len(headers))
+		for i, h := range headers {
+			jt.Headers[i] = toSnakeCase(fmt.Sprint(h)) // JSON-compatible keys
+		}
+		return
+	}
+	jt.Writer.AppendHeader(headers)
+}
+
+// AppendRow appends a row to the table and updates the JSON structure.
+func (jt *CustomTable) AppendRow(row table.Row, rowConfig ...table.RowConfig) {
+	if *jt.AsJson {
+		if jt.isArray {
+			jt.appendToArray(row)
+		} else {
+			jt.appendToHierarchy(row)
+		}
+		return
+	}
+	jt.Writer.AppendRow(row, rowConfig...)
+}
+
+// appendToArray handles rows for array-based tables (e.g., Smart Contracts).
+func (jt *CustomTable) appendToArray(row table.Row) {
+	if len(jt.Headers) == 0 {
+		panic("Headers must be set before appending rows.")
+	}
+	if len(row) > len(jt.Headers) {
+		panic("Row length exceeds header count.")
+	}
+
+	rowData := make(map[string]interface{})
+	for i, value := range row {
+		if i < len(jt.Headers) {
+			rowData[jt.Headers[i]] = noColorNoLines(fmt.Sprint(value))
+		}
+	}
+	jt.ArrayData = append(jt.ArrayData, rowData)
+}
+
+// appendToHierarchy handles rows for hierarchical tables
+func (jt *CustomTable) appendToHierarchy(row table.Row) {
+	if len(row) < 2 {
+		return
+	}
+
+	key := toSnakeCase(fmt.Sprint(row[0])) // Convert key to JSON-compatible
+	value := row[1]
+
+	// Check for nested rows
+	if len(row) > 2 {
+		if row[1] == row[2] {
+			jt.Data[key] = noColorNoLines(fmt.Sprint(value))
+			return
+		}
+		if _, ok := jt.Data[key]; !ok {
+			jt.Data[key] = make(map[string]interface{})
+		}
+		if subMap, ok := jt.Data[key].(map[string]interface{}); ok {
+			subKey := toSnakeCase(fmt.Sprint(row[1]))
+			subValue := noColorNoLines(fmt.Sprint(row[2]))
+			subMap[subKey] = subValue
+			jt.Data[key] = subMap
+		}
+	} else {
+		jt.Data[key] = noColorNoLines(fmt.Sprint(value))
+	}
+}
+
+// Renders all table as JSON.
+func (jt *CustomTable) PrintIfJson() {
+	if !*jt.AsJson {
+		return
+	}
+	jsonData, err := json.Marshal(jt.AllData)
+	Logger.OneShotUnmute()
+	if err != nil {
+		Logger.PrintToUser(fmt.Sprintf(`{"error": "failed to render JSON: %s"}`, err))
+		return
+	}
+	Logger.PrintToUser(string(jsonData))
+}
+
+// Render renders the table as a string or JSON based on the input flag.
+func (jt *CustomTable) Render() string {
+	if *jt.AsJson {
+		name := toSnakeCase(jt.Name)
+		if jt.isArray {
+			jt.AllData[name] = jt.ArrayData
+		} else {
+			jt.AllData[name] = jt.Data
+		}
+		return ""
+	}
+	return jt.Writer.Render()
+}
+
+func DefaultTable(title string, header table.Row) CustomTable {
+	t := NewCustomTable(title, header)
 	t.Style().Title.Align = text.AlignCenter
 	t.Style().Title.Format = text.FormatUpper
 	t.Style().Options.SeparateRows = true
 	t.SetTitle(title)
-	if header != nil {
-		t.AppendHeader(header)
-	}
 	return t
+}
+
+// Utils
+
+// Regex to match ANSI escape sequences
+var reColors = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// Regex to match parentheses
+var reParentheses = regexp.MustCompile(`\((.*?)\)`)
+
+// Regex to match non-alphanumeric characters
+var reNonAlphanumeric = regexp.MustCompile(`[^a-zA-Z0-9]+`)
+
+// noColorNoLines removes ANSI escape sequences and converts newlines to hyphens.
+func noColorNoLines(input string) string {
+	input = reColors.ReplaceAllString(input, "")
+	input = strings.ReplaceAll(input, "\n", "-")
+	return input
+}
+
+// toSnakeCase converts a string to snake_case. It removes ANSI escape sequences, replaces parentheses with underscores, and converts newlines to hyphens.
+func toSnakeCase(input string) string {
+
+	input = noColorNoLines(input)
+
+	input = reParentheses.ReplaceAllStringFunc(input, func(match string) string {
+		inner := strings.Trim(match, "()")
+		if inner == "" {
+			return "_"
+		}
+		return "_" + inner + "_"
+	})
+
+	input = reNonAlphanumeric.ReplaceAllString(input, "_")
+	input = strings.ToLower(strings.Trim(input, "_"))
+
+	return input
 }


### PR DESCRIPTION
## Why this should be merged

The addition of a `RenderJSON` method to the `table.Writer` enables native JSON rendering without requiring external transformations or custom code. This simplifies workflows for JSON-based applications. It enhances the flexibility of `go-pretty` while maintaining the existing rendering capabilities.

---

## How this works

A new `PrintIfJson` method is added to the `table.Writer`. It formats the table data (headers and rows) into structured JSON at the end of the command. 

- **Flat table example**:
  As table:
  ```
  +---------------------------------------------------------------------------------------------------------------------------+
  |                                                       ASH VALIDATORS                                                      |
  +------------------------------------------+---------------------------------------------------+--------+-------------------+
  | NODE ID                                  | VALIDATION ID                                     | WEIGHT | REMAINING BALANCE |
  +------------------------------------------+---------------------------------------------------+--------+-------------------+
  | NodeID-ECKiPtNQJrDYoGKma2yKaKzvuJT7V4HCz | bV23Ev9wL4pGYgfqVk88awYfshkGzfdgQ3w12h1hurX2r2hBR |   100  |               0.1 |
  +------------------------------------------+---------------------------------------------------+--------+-------------------+
  ```
  As json:
  ```json
   {
    "ash_validators": [
      {
        "node_id": "NodeID-ECKiPtNQJrDYoGKma2yKaKzvuJT7V4HCz",
        "remaining_balance": "0.1",
        "validation_id": "bV23Ev9wL4pGYgfqVk88awYfshkGzfdgQ3w12h1hurX2r2hBR",
        "weight": "100"
      }
    ]
  }
  ```

- **Grouped data example**:
  As table:
  ```
  +--------------------------------------------------------------------------------------------------------------------------------+
  |                                                               ASH                                                              |
  +---------------+----------------------------------------------------------------------------------------------------------------+
  | Name          | ash                                                                                                            |
  +---------------+----------------------------------------------------------------------------------------------------------------+
  | VM ID         | jvFW8PbuerjWravW4Gbfe8W1GsVSQNPrLncseZG8vTX5nwqWh                                                              |
  +---------------+----------------------------------------------------------------------------------------------------------------+
  | VM Version    | v0.7.0                                                                                                         |
  +---------------+----------------------------------------------------------------------------------------------------------------+
  | Validation    | Proof Of Authority                                                                                             |
  +---------------+--------------------------+-------------------------------------------------------------------------------------+
  | Local Network | ChainID                  | 7777                                                                                |
  |               +--------------------------+-------------------------------------------------------------------------------------+
  |               | SubnetID                 | GEieSy2doZ96bpMo5CuHPaX1LvaxpKZ9C72L22j94t6YyUb6X                                   |
  |               +--------------------------+-------------------------------------------------------------------------------------+
  |               | BlockchainID (CB58)      | fj65yEMzzb91Lo3EBawiHRqevQv2zoYGrH8CuopydnLGfFH56                                   |
  |               +--------------------------+-------------------------------------------------------------------------------------+
  |               | BlockchainID (HEX)       | 0x57ee6b52e3d3c948aca98e1ce4440e143bfacc7f8c1628a27b740423fd6ca12a                  |
  |               +--------------------------+-------------------------------------------------------------------------------------+
  |               | RPC Endpoint             | http://127.0.0.1:43287/ext/bc/fj65yEMzzb91Lo3EBawiHRqevQv2zoYGrH8CuopydnLGfFH56/rpc |
  +---------------+--------------------------+-------------------------------------------------------------------------------------+
  ```
  As json:
  ```json
  {
    "ash": {
      "local_network": {
        "blockchainid_cb58": "fj65yEMzzb91Lo3EBawiHRqevQv2zoYGrH8CuopydnLGfFH56",
        "blockchainid_hex": "0x57ee6b52e3d3c948aca98e1ce4440e143bfacc7f8c1628a27b740423fd6ca12a",
        "chainid": "7777",
        "rpc_endpoint": "http://127.0.0.1:43287/ext/bc/fj65yEMzzb91Lo3EBawiHRqevQv2zoYGrH8CuopydnLGfFH56/rpc",
        "subnetid": "GEieSy2doZ96bpMo5CuHPaX1LvaxpKZ9C72L22j94t6YyUb6X"
      },
      "name": "ash",
      "validation": "Proof Of Authority",
      "vm_id": "jvFW8PbuerjWravW4Gbfe8W1GsVSQNPrLncseZG8vTX5nwqWh",
      "vm_version": "v0.7.0"
    }
  }
  ```

---

## How this was tested

1. As the logic of commands was not altered, the testing task is about checking terminal output
2. Tested flat and hierarchical table structures.
3. Verified JSON rendering consistency using tools like `jq` to validate the format.
4. Tested on all commands ( no impact when not using --json )

---

## How is this documented

- Code comments

---

## How to test it (impacted command)

Run the following commands to validate JSON rendering integration:

- Build the project:
  ```bash
  ./scripts/build.sh
  ```
- Start a network with JSON output:
  ```bash
  ./bin/avalanche network start -j | jq
  ./bin/avalanche blockchain create ash
  ./bin/avalanche blockchain deploy ash -j -l -o | jq
  ./bin/avalanche blockchain describe -j ash | jq
  ./bin/avalanche validator list ash -l -j | jq
  ./bin/avalanche blockchain upgrade apply ash --local --force -j | jq
  ```

## Related feature request 

- https://github.com/jedib0t/go-pretty/issues/349